### PR TITLE
Add construction cost estimator and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,26 @@
 - 💞️ I’m looking to collaborate on healthcare solutions
 - 📫 How to reach me email is best
 - 😄 Pronouns: he
-- ⚡ Fun fact: my first language was RPG 
+- ⚡ Fun fact: my first language was RPG
+
+## Construction Cost Estimator
+
+This repository now includes a simple [construction cost estimator](cost_estimator.py).
+It demonstrates estimating the total project cost from first principles by summing
+material, labor, and equipment costs and then applying overhead and profit
+percentages.
+
+Run the example:
+
+```bash
+python cost_estimator.py
+```
+
+Or run the tests:
+
+```bash
+pytest
+```
 
 <!---
 fprestip/fprestip is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.

--- a/cost_estimator.py
+++ b/cost_estimator.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class Item:
+    """Represents a cost item with a quantity and a unit cost."""
+    name: str
+    quantity: float
+    unit_cost: float
+
+    def total(self) -> float:
+        """Return the total cost for the item."""
+        return self.quantity * self.unit_cost
+
+@dataclass
+class ProjectCost:
+    """Estimate cost of a construction project using first principles."""
+    materials: List[Item]
+    labor: List[Item]
+    equipment: List[Item]
+    overhead_percent: float = 0.0
+    profit_percent: float = 0.0
+
+    def total_materials(self) -> float:
+        return sum(item.total() for item in self.materials)
+
+    def total_labor(self) -> float:
+        return sum(item.total() for item in self.labor)
+
+    def total_equipment(self) -> float:
+        return sum(item.total() for item in self.equipment)
+
+    def subtotal(self) -> float:
+        return self.total_materials() + self.total_labor() + self.total_equipment()
+
+    def overhead(self) -> float:
+        return self.subtotal() * self.overhead_percent / 100
+
+    def profit(self) -> float:
+        return (self.subtotal() + self.overhead()) * self.profit_percent / 100
+
+    def total(self) -> float:
+        return self.subtotal() + self.overhead() + self.profit()
+
+if __name__ == "__main__":
+    # Example usage
+    materials = [
+        Item("Concrete", 100, 120),
+        Item("Steel", 50, 300),
+    ]
+    labor = [
+        Item("Carpenter", 80, 40),
+        Item("Electrician", 60, 50),
+    ]
+    equipment = [
+        Item("Crane", 10, 500),
+    ]
+    project = ProjectCost(
+        materials=materials,
+        labor=labor,
+        equipment=equipment,
+        overhead_percent=10,
+        profit_percent=5,
+    )
+    print(f"Total project cost: ${project.total():.2f}")

--- a/test_cost_estimator.py
+++ b/test_cost_estimator.py
@@ -1,0 +1,18 @@
+import math
+from cost_estimator import Item, ProjectCost
+
+def test_project_total():
+    materials = [Item("Material", 2, 10)]
+    labor = [Item("Labor", 3, 15)]
+    equipment = [Item("Equipment", 1, 50)]
+    project = ProjectCost(
+        materials=materials,
+        labor=labor,
+        equipment=equipment,
+        overhead_percent=10,
+        profit_percent=5,
+    )
+    subtotal = 2 * 10 + 3 * 15 + 1 * 50
+    overhead = subtotal * 0.10
+    expected_total = subtotal + overhead + (subtotal + overhead) * 0.05
+    assert math.isclose(project.total(), expected_total)


### PR DESCRIPTION
## Summary
- implement first-principles construction cost estimator with overhead and profit
- document usage in README
- add unit test validating total calculation

## Testing
- `python cost_estimator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae6779030483229399eeb41b968f59